### PR TITLE
Make sure git is installed

### DIFF
--- a/skale.js
+++ b/skale.js
@@ -118,7 +118,12 @@ function create(name) {
   }
   process.chdir(name);
   console.log('create local repository');
-  child_process.execSync('git init');
+  try {
+    child_process.execSync('git init');
+  } catch (err) {
+    console.log('It looks like you may not have git installed.  Skale needs that to run.  See https://git-scm.com/ for installation.');
+    return;
+  }
 
   var pkg = {
     name: name,
@@ -143,10 +148,13 @@ function create(name) {
   fs.writeFileSync('.gitignore', gitIgnore);
   var npm = child_process.spawnSync('npm', ['install'], {stdio: 'inherit'});
   if (npm.status) die('skale create error: npm install failed');
-  console.log('Project ' + name + ' is now ready.\n' +
+
+
+  console.log('\n----------------------------------' +
+    '\nProject ' + name + ' is now ready!\n' +
     'Please change directory to ' + name + ': "cd ' + name + '"\n' +
     'To run your app locally: "skale test"\n' +
-    'To modify your app: edit ' + name + '.js');
+    'To modify your app edit the file called ' + name + '.js');
 }
 
 function die(err) {


### PR DESCRIPTION
I added a bit of code here to catch the fail that would happen if an end user tries to run skale without git installed.  If it fails to execute the user will get a slightly nicer message indicating that they need to have git installed, and directing them to a web site where they can get additional information.  I also fiddled just a bit with the output of the create command to hopefully make clearer what should happen next.
